### PR TITLE
Fixed incorrect quote character.

### DIFF
--- a/src/unittests/unittests.lisp
+++ b/src/unittests/unittests.lisp
@@ -258,7 +258,7 @@ are discarded \(that is, the body is an implicit PROGN)."
 
   (defmacro our-let (binds &body body)
     "test let"
-    `((lambda ,(mapcar #’(lambda (x)
+    `((lambda ,(mapcar #'(lambda (x)
 			   (if (consp x) (car x) x))
 			 binds)
 	,@body)


### PR DESCRIPTION
Found incorrect quote character when I tried to use cls under ccl.
